### PR TITLE
Now supports single item array responses

### DIFF
--- a/amygdala.js
+++ b/amygdala.js
@@ -163,6 +163,7 @@ Amygdala.prototype._set = function(type, response, options) {
   // and store it under `store` for easy access.
   var store = this._store[type] ? this._store[type] : this._store[type] = {};
   var schema = this._schema[type];
+  var wrappedResponse = false;
 
   if (_.isString(response)) {
     // If the response is a string, try JSON.parse.
@@ -185,6 +186,7 @@ Amygdala.prototype._set = function(type, response, options) {
     } else {
       // Otherwise, just wrap it in an array and hope for the best.
       response = [response];
+      wrappedResponse = true;
     }
   }
 
@@ -268,7 +270,7 @@ Amygdala.prototype._set = function(type, response, options) {
   }.bind(this));
 
   // return our data as the original api call's response
-  return response.length === 1 ? response[0] : response;
+  return wrappedResponse && response.length === 1 ? response[0] : response;
 };
 
 Amygdala.prototype._setAjax = function(type, request, options) {

--- a/test/amygdala.test.js
+++ b/test/amygdala.test.js
@@ -161,6 +161,31 @@ describe('Amygdala', function() {
       expect(_.pluck(jsonStore._store['users'], 'name')).to.contain('Brandon Konkle');
     });
 
+    it('Single item result lists are returned correctly', function() {
+      // Create an empty store for this test
+      var jsonStore = new Amygdala(settings);
+
+      // Set the users with a JSON string
+      jsonStore._set('users', [userFixtures[0]]);
+
+      expect(Object.keys(jsonStore._store['users'])).to.have.length(1);
+      expect(_.pluck(jsonStore._store['users'], 'name')).to.contain('Martin');
+    });
+
+    it('Single item result is returned correctly', function() {
+      // Create an empty store for this test
+      var jsonStore = new Amygdala(settings);
+
+      // Set the users with a JSON string
+      jsonStore._set('users', userFixtures[0]);
+      expect(Object.keys(jsonStore._store['users'])).to.have.length(1);
+      
+      jsonStore._set('users', userFixtures[1]);
+      expect(Object.keys(jsonStore._store['users'])).to.have.length(2);
+      
+      expect(_.pluck(jsonStore._store['users'], 'name')).to.contain('Martin');
+    });
+
     it('will throw an error including the string if the JSON parse fails', function() {
       // Create an empty store for this test
       var jsonStore = new Amygdala(settings);


### PR DESCRIPTION
Now single item arrays response can be used as arrays instead of the object.