### PR TITLE
option to override idAttribute in schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ var store = new Amygdala({
   * url - relative path for each "table" (required)
   * orderBy - order by which you want to retrieve local cached data. eg (name, -name (for reverse))
   * parse - Accepts a parse method for cases when your API also returns extra meta data.
+  * idAttribute - overrides key attribute (if different in this schema)
 
 
 #### Schema relations:


### PR DESCRIPTION
There are APIs that use natural keys and do not provide synthetic, uniform ID attribute.
This adds support for providing schema specific attribute that contains unique identification string.