### PR TITLE
headers can now take functions

### DIFF
--- a/amygdala.js
+++ b/amygdala.js
@@ -108,7 +108,12 @@ Amygdala.prototype.ajax = function ajax(method, url, options) {
 
   if (!_.isEmpty(options.headers)) {
     _.each(options.headers, function(value, key) {
-      request.setRequestHeader(key, value);
+      if (_.isFunction(value)) {
+        request.setRequestHeader(key,value());
+      }
+      else {
+        request.setRequestHeader(key, value);
+      }
     });
   }
 


### PR DESCRIPTION
## Reason of the fork
I wanted to pass volatile headers to the schema ex: localStorage.token. The function made it possible !